### PR TITLE
Allow task execution via clicking the clock and battery

### DIFF
--- a/src/battery/battery.c
+++ b/src/battery/battery.c
@@ -56,6 +56,9 @@ static char buf_bat_time[20];
 int8_t battery_low_status;
 unsigned char battery_low_cmd_send;
 char *battery_low_cmd;
+char *battery_lclick_command;
+char *battery_mclick_command;
+char *battery_rclick_command;
 char *path_energy_now;
 char *path_energy_full;
 char *path_current_now;
@@ -112,6 +115,9 @@ void default_battery()
 	battery_state.percentage = 0;
 	battery_state.time.hours = 0;
 	battery_state.time.minutes = 0;
+	battery_lclick_command = 0;
+	battery_mclick_command = 0;
+	battery_rclick_command = 0;
 #if defined(__OpenBSD__) || defined(__NetBSD__)
 	apm_fd = -1;
 #endif
@@ -127,6 +133,9 @@ void cleanup_battery()
 	if (path_status) g_free(path_status);
 	if (battery_low_cmd) g_free(battery_low_cmd);
 	if (battery_timeout) stop_timeout(battery_timeout);
+	if (battery_lclick_command) g_free(battery_lclick_command);
+	if (battery_mclick_command) g_free(battery_mclick_command);
+	if (battery_rclick_command) g_free(battery_rclick_command);
 
 #if defined(__OpenBSD__) || defined(__NetBSD__)
 	if ((apm_fd != -1) && (close(apm_fd) == -1))
@@ -480,3 +489,19 @@ int resize_battery(void *obj)
 	return ret;
 }
 
+void battery_action(int button)
+{
+	char *command = 0;
+	switch (button) {
+		case 1:
+		command = battery_lclick_command;
+		break;
+		case 2:
+		command = battery_mclick_command;
+		break;
+		case 3:
+		command = battery_rclick_command;
+		break;
+	}
+	tint_exec(command);
+}

--- a/src/battery/battery.h
+++ b/src/battery/battery.h
@@ -55,6 +55,9 @@ extern int percentage_hide;
 
 extern int8_t battery_low_status;
 extern char *battery_low_cmd;
+extern char *battery_lclick_command;
+extern char *battery_mclick_command;
+extern char *battery_rclick_command;
 extern char *path_energy_now, *path_energy_full, *path_current_now, *path_status;
 
 // default global data
@@ -72,5 +75,7 @@ void init_battery_panel(void *panel);
 void draw_battery(void *obj, cairo_t *c);
 
 int  resize_battery(void *obj);
+
+void battery_action(int button);
 
 #endif

--- a/src/clock/clock.c
+++ b/src/clock/clock.c
@@ -39,6 +39,7 @@ char *time2_timezone;
 char *time_tooltip_format;
 char *time_tooltip_timezone;
 char *clock_lclick_command;
+char *clock_mclick_command;
 char *clock_rclick_command;
 struct timeval time_clock;
 PangoFontDescription *time1_font_desc;
@@ -61,6 +62,7 @@ void default_clock()
 	time_tooltip_format = 0;
 	time_tooltip_timezone = 0;
 	clock_lclick_command = 0;
+	clock_mclick_command = 0;
 	clock_rclick_command = 0;
 	time1_font_desc = 0;
 	time2_font_desc = 0;
@@ -77,6 +79,7 @@ void cleanup_clock()
 	if (time2_timezone) g_free(time2_timezone);
 	if (time_tooltip_timezone) g_free(time_tooltip_timezone);
 	if (clock_lclick_command) g_free(clock_lclick_command);
+	if (clock_mclick_command) g_free(clock_mclick_command);
 	if (clock_rclick_command) g_free(clock_rclick_command);
 	if (clock_timeout) stop_timeout(clock_timeout);
 }
@@ -263,6 +266,9 @@ void clock_action(int button)
 	switch (button) {
 		case 1:
 		command = clock_lclick_command;
+		break;
+		case 2:
+		command = clock_mclick_command;
 		break;
 		case 3:
 		command = clock_rclick_command;

--- a/src/clock/clock.h
+++ b/src/clock/clock.h
@@ -33,6 +33,7 @@ extern char *time_tooltip_timezone;
 extern PangoFontDescription *time1_font_desc;
 extern PangoFontDescription *time2_font_desc;
 extern char *clock_lclick_command;
+extern char *clock_mclick_command;
 extern char *clock_rclick_command;
 extern int clock_enabled;
 

--- a/src/config.c
+++ b/src/config.c
@@ -407,6 +407,10 @@ void add_entry (char *key, char *value)
 		if (strlen(value) > 0)
 			clock_lclick_command = strdup(value);
 	}
+	else if (strcmp(key, "clock_mclick_command") == 0) {
+		if (strlen(value) > 0)
+			clock_mclick_command = strdup(value);
+	}
 	else if (strcmp(key, "clock_rclick_command") == 0) {
 		if (strlen(value) > 0)
 			clock_rclick_command = strdup(value);

--- a/src/config.c
+++ b/src/config.c
@@ -289,6 +289,24 @@ void add_entry (char *key, char *value)
 	}
 
 	/* Battery */
+	else if (strcmp(key, "battery_lclick_command") == 0) {
+#ifdef ENABLE_BATTERY
+		if (strlen(value) > 0)
+			battery_lclick_command = strdup(value);
+#endif
+	}
+	else if (strcmp(key, "battery_mclick_command") == 0) {
+#ifdef ENABLE_BATTERY
+		if (strlen(value) > 0)
+			battery_mclick_command = strdup(value);
+#endif
+	}
+	else if (strcmp(key, "battery_rclick_command") == 0) {
+#ifdef ENABLE_BATTERY
+		if (strlen(value) > 0)
+			battery_rclick_command = strdup(value);
+#endif
+	}
 	else if (strcmp (key, "battery_low_status") == 0) {
 #ifdef ENABLE_BATTERY
 		battery_low_status = atoi(value);

--- a/src/panel.c
+++ b/src/panel.c
@@ -767,6 +767,18 @@ int click_clock(Panel *panel, int x, int y)
 	return FALSE;
 }
 
+int click_battery(Panel *panel, int x, int y)
+{
+	Battery bat = panel->battery;
+	if (panel_horizontal) {
+		if (bat.area.on_screen && x >= bat.area.posx && x <= (bat.area.posx + bat.area.width))
+			return TRUE;
+	} else {
+		if (bat.area.on_screen && y >= bat.area.posy && y <= (bat.area.posy + bat.area.height))
+			return TRUE;
+	}
+	return FALSE;
+}
 
 Area* click_area(Panel *panel, int x, int y)
 {

--- a/src/panel.h
+++ b/src/panel.h
@@ -153,6 +153,7 @@ Launcher *click_launcher (Panel *panel, int x, int y);
 LauncherIcon *click_launcher_icon (Panel *panel, int x, int y);
 int click_padding(Panel *panel, int x, int y);
 int click_clock(Panel *panel, int x, int y);
+int click_battery(Panel *panel, int x, int y);
 Area* click_area(Panel *panel, int x, int y);
 
 void autohide_show(void* p);

--- a/src/tint.c
+++ b/src/tint.c
@@ -373,7 +373,9 @@ int tint2_handles_click(Panel* panel, XButtonEvent* e)
 	if (tskbar && e->button == 1 && panel_mode == MULTI_DESKTOP)
 		return 1;
 	if (click_clock(panel, e->x, e->y)) {
-		if ( (e->button == 1 && clock_lclick_command) || (e->button == 3 && clock_rclick_command) )
+		if (  (e->button == 1 && clock_lclick_command) ||
+		      (e->button == 2 && clock_mclick_command) ||
+		      (e->button == 3 && clock_rclick_command) )
 			return 1;
 		else
 			return 0;

--- a/src/tint.c
+++ b/src/tint.c
@@ -380,6 +380,15 @@ int tint2_handles_click(Panel* panel, XButtonEvent* e)
 		else
 			return 0;
 	}
+	if (click_battery(panel, e->x, e->y)) {
+		if (  (e->button == 1 && battery_lclick_command) ||
+		      (e->button == 2 && battery_mclick_command) ||
+		      (e->button == 3 && battery_rclick_command) )
+			return 1;
+		else
+			return 0;
+	}
+
 	return 0;
 }
 
@@ -511,8 +520,16 @@ void event_button_release (XEvent *e)
 			break;
 	}
 
-	if ( click_clock(panel, e->xbutton.x, e->xbutton.y)) {
+	if (click_clock(panel, e->xbutton.x, e->xbutton.y)) {
 		clock_action(e->xbutton.button);
+		if (panel_layer == BOTTOM_LAYER)
+			XLowerWindow (server.dsp, panel->main_win);
+		task_drag = 0;
+		return;
+	}
+
+	if (click_battery(panel, e->xbutton.x, e->xbutton.y)) {
+		battery_action(e->xbutton.button);
 		if (panel_layer == BOTTOM_LAYER)
 			XLowerWindow (server.dsp, panel->main_win);
 		task_drag = 0;


### PR DESCRIPTION
There are two commits. One is a slightly altered version of the patch that was submitted for issue 430 on the google code page, and it adds the ability to execute tasks by middle-clicking the clock (left and right click is already implemented).

The other commit was originally authored by someone else, but altered by myself to add middle-clicking ability. It allows task execution via clicking the battery with any of the three mouse buttons.
